### PR TITLE
Update timeslots schema, adjust types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@algea_care/xpertyme-api",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@algea_care/xpertyme-api",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "LICENCE",
       "dependencies": {
         "dotenv": "^16.x.x",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algea_care/xpertyme-api",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Just a little lib for the xpertyme api",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/schemas/calendar/schema.ts
+++ b/schemas/calendar/schema.ts
@@ -385,8 +385,8 @@ export interface paths {
           "categories[]": number;
           /** Organization UUID */
           organizationUuid?: string;
-          /** Location UUID */
-          location_uuid?: string;
+          /** Address UUID */
+          addressUuid?: string;
           /** Spoken language ids */
           "spokenLanguages[]"?: number;
           /** Country (ISO 3166-1 alpha-2) */

--- a/schemas/calendar/schema.ts
+++ b/schemas/calendar/schema.ts
@@ -386,7 +386,7 @@ export interface paths {
           /** Organization UUID */
           organizationUuid?: string;
           /** Address UUID */
-          addressUuid?: string;
+          location_uuid?: string;
           /** Spoken language ids */
           "spokenLanguages[]"?: number;
           /** Country (ISO 3166-1 alpha-2) */

--- a/schemas/calendar/schema.ts
+++ b/schemas/calendar/schema.ts
@@ -385,7 +385,7 @@ export interface paths {
           "categories[]": number;
           /** Organization UUID */
           organizationUuid?: string;
-          /** Address UUID */
+          /** Location UUID */
           location_uuid?: string;
           /** Spoken language ids */
           "spokenLanguages[]"?: number;

--- a/scripts/calendar/timeslots_expertId.ts
+++ b/scripts/calendar/timeslots_expertId.ts
@@ -3,17 +3,17 @@ import { fetchTimeslots } from '../../src/calendar/timeslots'
 
 const run = async () => {
   const start = performance.now();
-
-  const slotsWithoutExpert = await fetchTimeslots({
+  const slots = await fetchTimeslots({
+    expertId: '38f667ab-da33-4f53-a22e-d0212bc53ffd',
     category: 19,
     dateEnd: new Date('2025-7-28'),
     dateStart: new Date('2025-5-5'),
     serviceType: 'statutory',
     visitingReasonTemplate: 'faba55be-a9f8-489d-92be-d4a21208b4f3'
-  });
+  })
   const end = performance.now();
   const durationInSeconds = (end - start) / 1000;
-  //console.log(slotsWithoutExpert)
+  console.log(slots)
   console.log(`Function took ${durationInSeconds.toFixed(3)} seconds.`);
 }
 

--- a/src/access-token.ts
+++ b/src/access-token.ts
@@ -1,6 +1,10 @@
 import { envConfig } from './config'
 import wretch from 'wretch'
+import fetch from 'node-fetch'
 import { AccessTokenResponse } from './types'
+
+// Configure wretch to use node-fetch
+const w = wretch().polyfills({ fetch })
 
 // so we don't keep requesting new tokens
 let token: AccessTokenResponse
@@ -40,19 +44,18 @@ export const getAccessToken = async () => {
     // set when we last requested to now
     lastRequested = new Date()
 
-    const tokenResponse = await wretch(
-      `${xpertyme.apiDomain}/${xpertyme.tokenPath}`
-    )
+    const tokenResponse = await w
+      .url(`${xpertyme.apiDomain}/${xpertyme.tokenPath}`)
       .auth(`Basic ${encodedKey()}`)
       .headers({
         'Content-Type': 'application/x-www-form-urlencoded',
-        Accept: '*/*'
+        'Accept': '*/*'
       })
       .formUrl({
         grant_type: 'client_credentials'
       })
       .post()
-      .res(async (r) => (await r.json()) as AccessTokenResponse)
+      .json<AccessTokenResponse>()
     if (!tokenResponse.access_token) {
       throw new Error('could not get the access token from expertyme')
     }

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,31 +1,40 @@
 import { envConfig } from './config'
 import wretch from 'wretch'
-import * as nodeFetch from 'node-fetch'
+import fetch from 'node-fetch'
 import { getAccessToken } from './access-token'
 import { retry } from 'wretch-middlewares'
 
-wretch().polyfills({
-  fetch: nodeFetch
-})
+// Configure wretch to use node-fetch
+const w = wretch().polyfills({ fetch })
 
 export const xpertymeApi = async (endPoint: string, withRetry = true) => {
   const { xpertyme } = envConfig()
 
   // get the access token for each request to the API
+  const start = performance.now();
   const token = await getAccessToken()
-  const url = `${xpertyme.apiDomain}/api/${endPoint}`
-  const middleWaresToAdd = []
+  const end = performance.now();
+  const durationInSeconds = (end - start) / 1000;
+  console.log(`Function getAccessToken took ${durationInSeconds.toFixed(3)} seconds.`);
+  const url = `${xpertyme.apiDomain}/${endPoint}`
+  
+  // Create a new wretch instance with the base URL
+  let request = w.url(url)
+    .auth(`Bearer ${token}`)
+    .headers({ 
+      'Accept': 'application/json',
+      'Content-Type': 'application/json'
+    })
+
+  // Add retry middleware if needed
   if (withRetry) {
-    middleWaresToAdd.push(
+    request = request.middlewares([
       retry({
         maxAttempts: 5,
         retryOnNetworkError: true
       })
-    )
+    ])
   }
-  console.log(url)
-  return wretch(url)
-    .middlewares(middleWaresToAdd)
-    .auth(`Bearer ${token}`)
-    .headers({ Accept: 'application/json' })
+
+  return request
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -31,6 +31,6 @@ export const xpertymeApi = async (endPoint: string, withRetry = true) => {
       })
     ])
   }
-
+  console.log(url);
   return request
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -11,11 +11,7 @@ export const xpertymeApi = async (endPoint: string, withRetry = true) => {
   const { xpertyme } = envConfig()
 
   // get the access token for each request to the API
-  const start = performance.now();
   const token = await getAccessToken()
-  const end = performance.now();
-  const durationInSeconds = (end - start) / 1000;
-  console.log(`Function getAccessToken took ${durationInSeconds.toFixed(3)} seconds.`);
   const url = `${xpertyme.apiDomain}/${endPoint}`
   
   // Create a new wretch instance with the base URL

--- a/src/calendar/cancel-event.ts
+++ b/src/calendar/cancel-event.ts
@@ -1,6 +1,6 @@
 import { xpertymeApi } from '../api'
 import { paths } from '../../schemas/calendar/schema'
-import { apiRoot } from '.'
+import { apiRoot } from './constants'
 
 type Path =
   paths['/api/calendarManager/v0/nba/{calendar}/events/{personalCalendarEvent}/cancel']['post']

--- a/src/calendar/confirm-event.ts
+++ b/src/calendar/confirm-event.ts
@@ -1,6 +1,6 @@
 import { xpertymeApi } from '../api'
 import { paths } from '../../schemas/calendar/schema'
-import { apiRoot } from '.'
+import { apiRoot } from './constants'
 
 type Path =
   paths['/api/calendarManager/v0/nba/{calendar}/events/{personalCalendarEvent}/confirm']['post']

--- a/src/calendar/constants.ts
+++ b/src/calendar/constants.ts
@@ -1,0 +1,1 @@
+export const apiRoot = 'calendarManager/v0'

--- a/src/calendar/create-event.ts
+++ b/src/calendar/create-event.ts
@@ -1,5 +1,5 @@
 import { xpertymeApi } from '../api'
-import { apiRoot } from '.'
+import { apiRoot } from './constants'
 import { XPTGender } from '../types'
 
 type Payload = {

--- a/src/calendar/index.ts
+++ b/src/calendar/index.ts
@@ -1,14 +1,13 @@
 import { cancelEvent } from './cancel-event'
 import { confirmEvent } from './confirm-event'
 import { createEvent } from './create-event'
-import { timeslots } from './timeslots'
-
-export const apiRoot = 'calendarManager/v0'
+import { timeslots, fetchTimeslots } from './timeslots'
 
 // api we export
 export default {
   createEvent,
   cancelEvent,
   confirmEvent,
-  timeslots
+  timeslots,
+  fetchTimeslots,
 }

--- a/src/calendar/timeslots.ts
+++ b/src/calendar/timeslots.ts
@@ -1,10 +1,13 @@
 import { xpertymeApi } from '../api'
-import { apiRoot } from '.'
+import { apiRoot } from './constants'
 import { paths } from '../../schemas/calendar/schema'
 
 type Path = paths['/api/calendarManager/v0/nba/{userUuid}/timeslots']['get']
 type Response = Path['responses']['200']['schema']
 
+/**
+ * @deprecated The method should not be used
+ */
 export const timeslots = async ({
   expertId,
   withRetry = true,
@@ -27,6 +30,35 @@ export const timeslots = async ({
   const apiCall = await xpertymeApi(
     // https://booking.algeacare.com/api/calendarManager/v0/nba/:expert/timeslots?dateStart=2023-08-15T00%3A00%3A00%2B00%3A00&dateEnd=2023-08-28T00%3A00%3A00%2B00%3A00&serviceType=statutory&categories[]=19&visitReasonTemplate=c6251937-0e6b-486d-9698-fb883f496ec7
     `${apiRoot}/nba/${expertId}/timeslots?dateStart=${encodeURI(
+      dateStart.toISOString()
+    )}&dateEnd=${dateEnd.toISOString()}&serviceType=${serviceType}&categories[]=${category}&visitReasonTemplate=${visitingReasonTemplate}`,
+    withRetry
+  )
+  const res = await apiCall.get().res()
+
+  return (await res.json()) as Response
+}
+export const fetchTimeslots = async ({
+  withRetry = true,
+  visitingReasonTemplate,
+  dateStart,
+  dateEnd,
+  serviceType,
+  category,
+  expertId
+  }: {
+  withRetry?: boolean
+  visitingReasonTemplate: string
+  dateStart: Date
+  dateEnd: Date
+  serviceType: string
+  // 1 for cbd 2 for thc for prod
+  // 19 or 12 for staging
+  category: number,
+  expertId?: string
+}) => {
+  const apiCall = await xpertymeApi(
+    `api/calendarManager/v0/nba/${expertId ? expertId+'/' : ''}timeslots?dateStart=${encodeURI(
       dateStart.toISOString()
     )}&dateEnd=${dateEnd.toISOString()}&serviceType=${serviceType}&categories[]=${category}&visitReasonTemplate=${visitingReasonTemplate}`,
     withRetry

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,3 +8,13 @@ export type AccessTokenResponse = {
 }
 
 export type XPTGender = 'male' | 'female' | 'undefined' | 'diverse'
+
+export const XPTAppointment = {
+  THC_ON_SITE : 'thc_on_site',
+  THC_VIDEO_EG : 'thc_video_eg',
+  THC_VIDEO : 'thc_video',
+  CBD_VIDEO : 'cbd_video',
+  NO_APPOINTMENT : 'no_appointment',
+  UNMAPPED_APPOINTMENT : 'unmapped_appointment',
+}
+export type XPTAppointmentType = keyof typeof XPTAppointment


### PR DESCRIPTION
Changed the incorrect property `get.parameters.query.addressUuid` _(API doesn't support this property and returns with error)_ to the correct `location_uuid` in `/api/calendarManager/v0/nba/timeslots` schema
Added types `XPTAppointmentType`, `XPTAppointment`
Bug fixed (recursive dependencies, `TypeError: (intermediate value)(...)(...) is not a function`)